### PR TITLE
Add refresh token persistence and refresh endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ auth_service/
 ```
 
 All other services follow a similar layout, customised for their domain.
+
+### Auth Service API
+
+The auth service exposes a `/auth/refresh` endpoint. Send a JSON body containing
+`{"refresh_token": "<token>"}` to obtain a new access token when the previous
+one expires. Tables, including `refresh_tokens`, are automatically created on
+startup.

--- a/auth_service/app/api/routes_auth.py
+++ b/auth_service/app/api/routes_auth.py
@@ -39,8 +39,20 @@ def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depend
     roles = auth_service.get_user_roles(user)
     token_data = {"sub": str(user.id), "roles": roles}
     access_token = auth_service.create_access_token(token_data)
-    refresh_token = auth_service.create_refresh_token(user.id)
+    refresh_token = auth_service.create_refresh_token(db, user.id)
     return schemas.Token(access_token=access_token, refresh_token=refresh_token)
+
+
+@router.post("/refresh", response_model=schemas.Token)
+def refresh_token(token_in: schemas.RefreshTokenRequest, db: Session = Depends(get_db)) -> Any:
+    """Issue a new access token based on a valid refresh token."""
+    user = auth_service.verify_refresh_token(db, token_in.refresh_token)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid or expired refresh token")
+    roles = auth_service.get_user_roles(user)
+    token_data = {"sub": str(user.id), "roles": roles}
+    access_token = auth_service.create_access_token(token_data)
+    return schemas.Token(access_token=access_token, refresh_token=token_in.refresh_token)
 
 
 @router.get("/me", response_model=schemas.UserOut)

--- a/auth_service/app/schemas/auth.py
+++ b/auth_service/app/schemas/auth.py
@@ -14,6 +14,10 @@ class Token(BaseModel):
     refresh_token: Optional[str]
 
 
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+
 class TokenData(BaseModel):
     user_id: int
     roles: List[str]


### PR DESCRIPTION
## Summary
- persist refresh tokens in database
- implement `verify_refresh_token`
- expose `/auth/refresh` route
- document refresh endpoint

## Testing
- `python -m py_compile auth_service/app/services/auth.py auth_service/app/api/routes_auth.py auth_service/app/schemas/auth.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863a9eda7c83309772a5bf0ecefc54