### PR TITLE
Add refresh token tests

### DIFF
--- a/auth_service/app/schemas/__init__.py
+++ b/auth_service/app/schemas/__init__.py
@@ -1,1 +1,19 @@
-# Pydantic schemas for the auth service are exposed in submodules.
+"""Exports auth service Pydantic schemas for easy access."""
+
+from .auth import (
+    Token,
+    RefreshTokenRequest,
+    TokenData,
+    UserCreate,
+    UserLogin,
+    UserOut,
+)
+
+__all__ = [
+    "Token",
+    "RefreshTokenRequest",
+    "TokenData",
+    "UserCreate",
+    "UserLogin",
+    "UserOut",
+]

--- a/auth_service/tests/test_refresh.py
+++ b/auth_service/tests/test_refresh.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import pathlib
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+# Use SQLite for tests
+DB_PATH = "test_auth.db"
+os.environ["DATABASE_URL"] = f"sqlite:///{DB_PATH}"
+
+# Ensure service package is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from auth_service.app.main import create_app
+from auth_service.app.database import SessionLocal
+from auth_service.app.models.user import RefreshToken
+
+@pytest.fixture(scope="module")
+def client():
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+    app = create_app()
+    with TestClient(app) as c:
+        yield c
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+
+@pytest.fixture(autouse=True)
+def mock_publish_event():
+    with patch("auth_service.app.services.auth.publish_event") as mock:
+        yield mock
+
+def test_refresh_token_flow(client):
+    email = "user@example.com"
+    password = "strongpassword"
+
+    resp = client.post("/auth/register", json={"email": email, "password": password})
+    assert resp.status_code == 201
+
+    resp = client.post("/auth/login", data={"username": email, "password": password})
+    assert resp.status_code == 200
+    tokens = resp.json()
+    refresh_token = tokens.get("refresh_token")
+    assert refresh_token
+
+    # Verify refresh token persisted
+    with SessionLocal() as db:
+        assert db.query(RefreshToken).filter(RefreshToken.token == refresh_token).first()
+
+    resp = client.post("/auth/refresh", json={"refresh_token": refresh_token})
+    assert resp.status_code == 200
+    new_tokens = resp.json()
+    assert new_tokens["refresh_token"] == refresh_token
+    assert new_tokens["access_token"]
+    assert new_tokens["token_type"] == "bearer"


### PR DESCRIPTION
## Summary
- expose auth schemas at package level
- add pytest to validate refresh token workflow

## Testing
- `pytest auth_service/tests/test_refresh.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68863c5a3b088330a180b472139adf14