### PR TITLE
Fix routes_auth docstring path

### DIFF
--- a/auth_service/app/api/routes_auth.py
+++ b/auth_service/app/api/routes_auth.py
@@ -1,5 +1,5 @@
 """
-📄 File: auth_service/app/routes/routes_auth.py
+📄 File: auth_service/app/api/routes_auth.py
 
 Auth service API routes.
 


### PR DESCRIPTION
## Summary
- correct the reference path in the initial docstring of `routes_auth.py`

## Testing
- `pip install -r auth_service/requirements.txt`
- `pytest -q auth_service/tests` *(fails: ImportError due to incompatible dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688647f5b47c83308d281064252318dc