### PR TITLE
Add authentication tests for /auth/me

### DIFF
--- a/auth_service/tests/conftest.py
+++ b/auth_service/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from types import SimpleNamespace
 import pytest
@@ -17,6 +18,10 @@ def client(monkeypatch):
             pass
 
     sys.modules.setdefault("kafka", SimpleNamespace(KafkaProducer=DummyProducer))
+
+    # Provide required JWT settings for the auth service
+    os.environ.setdefault("JWT_SECRET_KEY", "testsecret")
+    os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
 
     from auth_service.app import database as database_module
     from auth_service.app.models.base import Base
@@ -42,6 +47,9 @@ def client(monkeypatch):
         "UserOut",
         "Token",
         "RefreshTokenRequest",
+        "ChangePasswordRequest",
+        "PasswordResetRequest",
+        "ResetPasswordRequest",
     ):
         setattr(schemas_pkg, name, getattr(auth_schemas, name))
 

--- a/auth_service/tests/test_auth_endpoints.py
+++ b/auth_service/tests/test_auth_endpoints.py
@@ -50,18 +50,47 @@ def test_login_and_refresh(client):
     assert refreshed["refresh_token"] == token["refresh_token"]
 
 
-def test_me_not_implemented(client):
+def test_me_requires_auth_and_returns_user(client):
+    """Verify /auth/me requires authentication and returns the current user."""
+
+    # Unauthenticated request should be rejected
     resp = client.get("/auth/me")
-    # dependency is missing, so FastAPI returns 422
-    assert resp.status_code == 422
+    assert resp.status_code == 401
+
+    # Register and login to obtain a valid token
+    reg = client.post(
+        "/auth/register",
+        json={"email": "me@example.com", "password": "pass1234"},
+    )
+    user_id = reg.json()["id"]
+
+    login = client.post(
+        "/auth/login",
+        data={"username": "me@example.com", "password": "pass1234"},
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+
+    # JWT should decode to the correct user id
+    from auth_service.app.services.auth import decode_access_token
+
+    payload = decode_access_token(token)
+    assert payload and payload.user_id == user_id
+
+    # Authenticated call should return the user details
+    resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == user_id
+    assert data["email"] == "me@example.com"
 
 
 def test_forgot_and_reset_missing(client):
     resp1 = client.post("/auth/forgot-password", json={"email": "a@b.com"})
     resp2 = client.post(
         "/auth/reset-password",
-        json={"token": "t", "password": "newpass123"},
+        json={"token": "t", "new_password": "newpass123"},
     )
     assert resp1.status_code == 404
-    assert resp2.status_code == 404
+    assert resp2.status_code == 400
 


### PR DESCRIPTION
## Summary
- update test fixtures to set required JWT env vars
- expose additional schema classes in tests
- add new tests verifying `/auth/me` endpoint authentication
- fix reset password test payload

## Testing
- `pytest -q auth_service/tests/test_auth_endpoints.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_688647fe10588330b1614f0dfb7aba2b