### PR TITLE
Update schemas in auth tests

### DIFF
--- a/auth_service/tests/conftest.py
+++ b/auth_service/tests/conftest.py
@@ -42,6 +42,9 @@ def client(monkeypatch):
         "UserOut",
         "Token",
         "RefreshTokenRequest",
+        "ChangePasswordRequest",
+        "PasswordResetRequest",
+        "ResetPasswordRequest",
     ):
         setattr(schemas_pkg, name, getattr(auth_schemas, name))
 


### PR DESCRIPTION
## Summary
- ensure additional auth models are exposed at package level for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kafka.vendor.six.moves')*

------
https://chatgpt.com/codex/tasks/task_e_688647e7bf08833097b8b4c920ed159a